### PR TITLE
Adding Properties to the BillingPlan Model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cashbox (0.0.1)
+    cashbox (0.0.2)
       activesupport
       addressable
       hashie
@@ -10,9 +10,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.2)
+    activesupport (5.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.0)
@@ -29,12 +29,13 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.3)
     hashdiff (0.3.2)
-    hashie (3.5.5)
-    httparty (0.15.6)
+    hashie (3.5.7)
+    httparty (0.16.2)
       multi_xml (>= 0.5.2)
-    i18n (0.8.1)
+    i18n (1.0.0)
+      concurrent-ruby (~> 1.0)
     method_source (0.8.2)
-    minitest (5.10.1)
+    minitest (5.11.3)
     multi_xml (0.6.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -64,7 +65,7 @@ GEM
     safe_yaml (1.0.4)
     slop (3.6.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.2)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     webmock (2.3.2)
       addressable (>= 2.3.6)
@@ -84,4 +85,4 @@ DEPENDENCIES
   webmock (~> 2.0)
 
 BUNDLED WITH
-   1.13.6
+   1.16.1

--- a/lib/cashbox/model/billing_plan.rb
+++ b/lib/cashbox/model/billing_plan.rb
@@ -12,5 +12,7 @@ module Cashbox
     property :message
     property :periods, coerce: Cashbox::Type.List(Cashbox::BillingPlanPeriod)
     property :status
+    property :times_to_run
+    property :used_on_subscriptions
   end
 end

--- a/lib/cashbox/version.rb
+++ b/lib/cashbox/version.rb
@@ -1,3 +1,3 @@
 module Cashbox
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/spec/unit/model/billing_plan_spec.rb
+++ b/spec/unit/model/billing_plan_spec.rb
@@ -13,6 +13,8 @@ describe Cashbox::BillingPlan do
   it { is_expected.to have_property(:message) }
   it { is_expected.to have_property(:periods) }
   it { is_expected.to have_property(:status) }
+  it { is_expected.to have_property(:times_to_run) }
+  it { is_expected.to have_property(:used_on_subscriptions) }
 
   its(:object) { is_expected.to eql('BillingPlan') }
 end


### PR DESCRIPTION
https://legalshield.atlassian.net/browse/AD-1191

The property used_on_subscriptions is not documented in the REST documentation but is showing up in the response. I have communicated this to Vinidicia. The other property does show in the documentation but was left out.