### PR TITLE
Adding error handling to the model objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /tmp/
 /.DS_store
 examples.rb
+.idea/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cashbox (0.0.3)
+    cashbox (0.0.4)
       activesupport
       addressable
       hashie
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.6)
+    activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -32,7 +32,7 @@ GEM
     hashie (3.5.7)
     httparty (0.16.2)
       multi_xml (>= 0.5.2)
-    i18n (1.0.0)
+    i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     method_source (0.8.2)
     minitest (5.11.3)

--- a/lib/cashbox/exception.rb
+++ b/lib/cashbox/exception.rb
@@ -7,5 +7,4 @@ module Cashbox
       super(message)
     end
   end
-
 end

--- a/lib/cashbox/exception.rb
+++ b/lib/cashbox/exception.rb
@@ -1,4 +1,11 @@
 module Cashbox
   class Exception < Exception
   end
+
+  class SaveError < StandardError
+    def initialize(message)
+      super(message)
+    end
+  end
+
 end

--- a/lib/cashbox/model/model.rb
+++ b/lib/cashbox/model/model.rb
@@ -1,9 +1,29 @@
 module Cashbox
+  class ErrorMessages
+    attr_accessor :messages
+
+    def initialize
+      @messages = {}
+    end
+  end
+
   class Model < Hashie::Trash
     include Hashie::Extensions::MergeInitializer
     include Hashie::Extensions::IgnoreUndeclared
     include Hashie::Extensions::IndifferentAccess
     include Hashie::Extensions::Dash::PropertyTranslation
     include Hashie::Extensions::Dash::Coercion
+
+    property :message
+    property :type
+    property :code
+    property :url
+
+    def errors
+      error_messages = ErrorMessages.new
+
+      error_messages.messages = Hash[type, [message, code, url]]
+      error_messages
+    end
   end
 end

--- a/lib/cashbox/model/model.rb
+++ b/lib/cashbox/model/model.rb
@@ -22,6 +22,8 @@ module Cashbox
     def errors
       error_messages = ErrorMessages.new
 
+      return error_messages if message.nil?
+
       error_messages.messages = Hash[type, [message, code, url]]
       error_messages
     end

--- a/lib/cashbox/repository.rb
+++ b/lib/cashbox/repository.rb
@@ -30,11 +30,17 @@ module Cashbox
     end
 
     def save
-      request = Cashbox::Request.new(:post, route(@instance.vid), { body: @instance.to_json })
-      cast(request.response)
+      _save
     end
 
     private
+
+    def _save
+      request = Cashbox::Request.new(:post, route(@instance.vid), { body: @instance.to_json })
+      #TODO Once test is ready, add the following and throw a SaveException to make the test pass.
+      #return cast(request.response) unless request.message?
+      case(request.response)
+    end
 
     def _where(query, max)
       query = Hashie::Mash.new(query)

--- a/lib/cashbox/repository.rb
+++ b/lib/cashbox/repository.rb
@@ -1,5 +1,6 @@
 require 'active_support/inflector'
 require 'addressable/uri'
+require_relative 'exception'
 
 module Cashbox
   class Repository
@@ -32,14 +33,14 @@ module Cashbox
 
     def save
       _save
+      return @instance if @instance.errors.messages.empty?
+      raise Cashbox::SaveError.new("#{@instance.type}: #{@instance.code}: #{@instance.message} [#{@instance.url}]")
     end
 
     private
 
     def _save
       request = Cashbox::Request.new(:post, route(@instance.vid), { body: @instance.to_json })
-      #TODO Once test is ready, add the following and throw a SaveException to make the test pass.
-      #return cast(request.response) unless request.message?
       cast(request.response)
     end
 

--- a/lib/cashbox/repository.rb
+++ b/lib/cashbox/repository.rb
@@ -3,6 +3,7 @@ require 'addressable/uri'
 
 module Cashbox
   class Repository
+
     DEFAULT_LIMIT = 100.freeze
 
     attr_reader :instance
@@ -39,7 +40,7 @@ module Cashbox
       request = Cashbox::Request.new(:post, route(@instance.vid), { body: @instance.to_json })
       #TODO Once test is ready, add the following and throw a SaveException to make the test pass.
       #return cast(request.response) unless request.message?
-      case(request.response)
+      cast(request.response)
     end
 
     def _where(query, max)

--- a/spec/unit/model/model_spec.rb
+++ b/spec/unit/model/model_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Cashbox::Model do
+  it { is_expected.to have_property(:message) }
+  it { is_expected.to have_property(:type) }
+  it { is_expected.to have_property(:code) }
+  it { is_expected.to have_property(:url) }
+
+  describe "#errors" do
+    let(:model) { Cashbox::Model.new }
+
+    before do
+      model.message = 'Test message'
+      model.type = 'test'
+      model.code = 'TST'
+      model.url = 'www.testing.legalshield'
+    end
+
+    it "returns the error messages with the type as the hash key" do
+      expect(model.errors.messages.has_key?('test')).to eq(true)
+    end
+
+    it "returns the expected error message" do
+      expect(model.errors.messages['test'][0]).to eq('Test message')
+    end
+
+    it "returns the expected error code" do
+      expect(model.errors.messages['test'][1]).to eq('TST')
+    end
+
+    it "returns the expected error code" do
+      expect(model.errors.messages['test'][2]).to eq('www.testing.legalshield')
+    end
+  end
+end

--- a/spec/unit/model/model_spec.rb
+++ b/spec/unit/model/model_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Cashbox::Model do
   it { is_expected.to have_property(:message) }

--- a/spec/unit/model/model_spec.rb
+++ b/spec/unit/model/model_spec.rb
@@ -31,5 +31,11 @@ describe Cashbox::Model do
     it "returns the expected error code" do
       expect(model.errors.messages['test'][2]).to eq('www.testing.legalshield')
     end
+
+    it "does not populate the error messages if there is no message" do
+      model.message = nil;
+
+      expect(model.errors.messages.empty?).to eq(true)
+    end
   end
 end

--- a/spec/unit/repository_spec.rb
+++ b/spec/unit/repository_spec.rb
@@ -216,8 +216,8 @@ describe Cashbox::Repository do
               .and_return(double('request', response: failure_response))
         end
 
-        it 'has the expected error message' do
-          expect(result.errors.messages['card_error_test'][0]).to eq('This is a test error message.')
+        it 'throws an exception' do
+          expect( -> {result.save}).to raise_exception(Cashbox::SaveError)
         end
       end
     end

--- a/spec/unit/repository_spec.rb
+++ b/spec/unit/repository_spec.rb
@@ -207,16 +207,17 @@ describe Cashbox::Repository do
       end
 
       context 'failure' do
-        let(:failure_response) { Mash.new({message: "This is a test error message."}) }
+        let(:failure_response) { Hashie::Mash.new({type: 'card_error_test', code: 'expired card (test)', message: 'This is a test error message.', url: 'http://developer.vindicia.com/api#expired_card'}) }
+
         before do
           allow(Cashbox::Request)
               .to receive(:new)
               .with(:post, '/accounts/vid-1', { body: model.to_json })
-              .and_return(failure_response)
+              .and_return(double('request', response: failure_response))
         end
 
-        it "throws a SaveException" do
-
+        it 'saves errors in the model object' do
+          expect(result.errors.messages['card_error_test'][0]).to eq('This is a test error message.')
         end
       end
     end

--- a/spec/unit/repository_spec.rb
+++ b/spec/unit/repository_spec.rb
@@ -216,7 +216,7 @@ describe Cashbox::Repository do
               .and_return(double('request', response: failure_response))
         end
 
-        it 'saves errors in the model object' do
+        it 'has the expected error message' do
           expect(result.errors.messages['card_error_test'][0]).to eq('This is a test error message.')
         end
       end

--- a/spec/unit/repository_spec.rb
+++ b/spec/unit/repository_spec.rb
@@ -205,6 +205,20 @@ describe Cashbox::Repository do
           expect(result.object_id).to eq(model.object_id)
         end
       end
+
+      context 'failure' do
+        let(:failure_response) { Mash.new({message: "This is a test error message."}) }
+        before do
+          allow(Cashbox::Request)
+              .to receive(:new)
+              .with(:post, '/accounts/vid-1', { body: model.to_json })
+              .and_return(failure_response)
+        end
+
+        it "throws a SaveException" do
+
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://legalshield.atlassian.net/browse/AM01-375
This pull addresses the following item in the story:
* The save method should set an errors object on the Model like Active Record does when there are errors that occur.

The other items in the story are not being addressed at this time and may be broke out into separate stories for post-MVP work.  The remaining items are:
* The save method should return true if successful, or false if there is an error created.
* The repository.rb should implement a save! method, which should throw the error object instead of setting it on the model.