### PR TITLE
Update ReadMe. Pushed up the Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cashbox (0.0.37)
+    cashbox (0.0.41)
       activesupport
       addressable
       hashie
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.0)
+    activesupport (5.2.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -23,19 +23,23 @@ GEM
       slop (~> 3.6)
     coderay (1.1.2)
     columnize (0.9.0)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debugger-linecache (1.2.0)
     diff-lcs (1.3)
     hashdiff (0.3.7)
-    hashie (3.5.7)
-    httparty (0.16.2)
+    hashie (4.0.0)
+    httparty (0.17.3)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.0.1)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
-    minitest (5.11.3)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
+    minitest (5.13.0)
     multi_xml (0.6.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -64,7 +68,7 @@ GEM
     safe_yaml (1.0.4)
     slop (3.6.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     webmock (2.3.2)
       addressable (>= 2.3.6)
@@ -84,4 +88,4 @@ DEPENDENCIES
   webmock (~> 2.0)
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ account.save
 
 After checking out the repo, run `bundle install` to install dependencies. Then, run `bundle exec rake` to run the tests. You can also run `bundle console` for an interactive prompt that will allow you to experiment.
 
+To push a new version of the Cashbox ruby gem, you will need to update the version file with the new version, run `bundle install` and be sure to also push the `Gemfile.lock` file up with your code changes to be merged to master. Then, run this command in your terminal to build the gemspec `gem build cashbox.gemspec`. Once the gemspec is built and your code has been merged to master, you can now push the new version to ruby gems by running this command in your terminal: `gem push cashbox-<version number of built gem>.gem` and replace the verbiage within the angle brackets with the new version number.
+
 ### Logging
 
 You can log the request and response of a call to Vindicia by defining a block in your calling application and passing it to this gem.


### PR DESCRIPTION
This mostly just updates the ReadMe to have more clear instructions for creating and pushing a new version of the Cashbox gem but also includes the changes to the Gemfile.lock file that I missed merging in with our previous code changes.