### PR TITLE
Publishing new version of cashbox gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cashbox (0.0.41)
+    cashbox (0.0.42)
       activesupport
       addressable
       hashie

--- a/lib/cashbox/version.rb
+++ b/lib/cashbox/version.rb
@@ -1,3 +1,3 @@
 module Cashbox
-  VERSION = "0.0.41"
+  VERSION = "0.0.42"
 end


### PR DESCRIPTION
Apparently ruby gems does not allow you to repush versions so we needed to make an adjustment and create a new version to be published.